### PR TITLE
target Python 3.9 in tests

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7']
+        python-version: ['3.9']
     steps:
       - name: Check out repository
         uses: actions/checkout@v2

--- a/.github/workflows/test-pip.yml
+++ b/.github/workflows/test-pip.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7']
+        python-version: ['3.9']
     steps:
       - name: Check out repository
         uses: actions/checkout@v2


### PR DESCRIPTION
tests may fail but this is good so that we can test the improvements
of environments against Python 3.9