### PR TITLE
Test python 3.9-3.11 on pip, and 3.11 on conda

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.9']
+        python-version: ['3.11']
     steps:
       - name: Check out repository
         uses: actions/checkout@v2

--- a/.github/workflows/test-pip.yml
+++ b/.github/workflows/test-pip.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.9']
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - name: Check out repository
         uses: actions/checkout@v2


### PR DESCRIPTION
- conda takes much longer so test only the latest
- Test a few recent versions with pip
- Main review question: is it worth all of CPU time to do this?
