### PR TITLE
jupyter labextension/serverextension not needed for jupyterlab_git?

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,7 +1,3 @@
 #!/bin/bash
 
 jupyter labextension install @jupyter-widgets/jupyterlab-manager
-
-# JupyterLab Git extension
-jupyter labextension install @jupyterlab/git
-jupyter serverextension enable --py jupyterlab_git


### PR DESCRIPTION
Otherwise the Binder environment fails.