### PR TITLE
Use almost latest snakemake

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - pytest=8.0.2
   - pytest-cov=4.1.0
   - seaborn=0.13.2
-  - snakemake-minimal=8.5.3
+  - snakemake-minimal=8.30.0
   - pulp<2.8.0
   - sphinx=7.2.6
   - sphinx-autobuild=2024.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pandas==2.2.1
 pytest==8.0.2
 pytest-cov==4.1.0
 seaborn==0.13.2
-snakemake==8.5.3
+snakemake==8.30.0
 pulp<2.8.0
 sphinx==7.2.6
 sphinx-autobuild==2024.2.4


### PR DESCRIPTION
Very latest (9) is very new. To be safe, sticking to version 8 for now. 

I unfortunately do not understand why the build fails. 